### PR TITLE
fix: Use gsutil cp instead of mv

### DIFF
--- a/charts/neo4j-backup/templates/deployment.yaml
+++ b/charts/neo4j-backup/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
                   if [ ! -d "/mnt/gcs/{{ .Values.name }}" ]; then
                     mkdir /mnt/gcs/{{ .Values.name }}
                   fi
-                  mv /mnt/backups/{{ .Values.name }}/* /mnt/gcs/{{ .Values.name }}
+                  gsutil cp /mnt/backups/{{ .Values.name }}/* gs://{{ .Values.bucket }}/{{ .Values.name }}/
               volumeMounts:
                 - name: gcs-creds-volume
                   mountPath: /etc/gcloud


### PR DESCRIPTION
The buckets are locked so mv creates an empty file with 0B then writing to the file fails
Use gsutil to upload directly instead
